### PR TITLE
VolumeRepo implementations for superset and subsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,59 @@ PATH
   remote: .
   specs:
     datasets (0.1.0)
+      oj
+      resque
+      resque-pool
+      resque-retry
+      resque-scheduler
       rpairtree
+      sequel
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    i18n (0.8.1)
+    method_source (0.8.2)
+    minitest (5.10.1)
+    mono_logger (1.1.0)
+    multi_json (1.12.1)
+    oj (2.18.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
     rake (10.5.0)
+    redis (3.3.3)
+    redis-namespace (1.5.3)
+      redis (~> 3.0, >= 3.0.4)
+    resque (1.27.2)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+    resque-pool (0.6.0)
+      rake
+      resque (~> 1.22)
+    resque-retry (1.5.0)
+      resque (~> 1.25)
+      resque-scheduler (~> 4.0)
+    resque-scheduler (4.3.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.3)
+      resque (~> 1.26)
+      rufus-scheduler (~> 3.2)
     rpairtree (0.2.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -23,15 +69,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rufus-scheduler (3.3.4)
+      tzinfo
+    sequel (4.44.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tilt (2.0.6)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    vegas (0.1.11)
+      rack (>= 1.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   bundler (~> 1.13)
   datasets!
+  pry
   rake (~> 10.0)
   rspec (~> 3.0)
+  sqlite3
 
 BUNDLED WITH
    1.13.6

--- a/datasets.gemspec
+++ b/datasets.gemspec
@@ -20,8 +20,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rpairtree"
+  spec.add_runtime_dependency "resque"
+  spec.add_runtime_dependency "resque-retry"
+  spec.add_runtime_dependency "resque-pool"
+  spec.add_runtime_dependency "resque-scheduler"
+  spec.add_runtime_dependency "oj"
+  spec.add_runtime_dependency "sequel"
 
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "activesupport"
+  spec.add_development_dependency "pry"
 end

--- a/lib/datasets/repository/feed_backend.rb
+++ b/lib/datasets/repository/feed_backend.rb
@@ -1,0 +1,32 @@
+require "set"
+require "sequel"
+
+module Repository
+  class FeedBackend
+
+    def initialize(connection)
+      @connection = connection
+      @table_name = :feed_audit
+    end
+
+    # Retrieve all unique volumes that have had a change in
+    # their rights within the given time period.
+    # The list is unordered.
+    # @param [Time] start_time
+    # @param [Time] end_time
+    # @return Set<Hash> Each hash contains exactly the keys *:namespace*
+    #   and *:id*.
+    def changed_between(start_time, end_time)
+      connection[table_name]
+        .where(zip_date: start_time..end_time)
+        .exclude_where(zipcheck_ok: false)
+        .select(:namespace, :id)
+        .to_set
+    end
+
+    private
+
+    attr_reader :connection, :table_name
+
+  end
+end

--- a/lib/datasets/repository/rights_feed_volume_repo.rb
+++ b/lib/datasets/repository/rights_feed_volume_repo.rb
@@ -1,0 +1,27 @@
+require "datasets/volume_repo"
+
+module Repository
+  class RightsFeedVolumeRepo < VolumeRepo
+
+    def initialize(rights_backend:, feed_backend:)
+      @rights_backend = rights_backend
+      @feed_backend = feed_backend
+    end
+
+    # Retrieve all unique volumes that have had a changed
+    # within the given time period.  The list is unordered.
+    # @param [Time] start_time
+    # @param [Time] end_time
+    # @return Set<Volume>
+    def changed_between(start_time, end_time)
+      tuples_from_feed = feed_backend.changed_between(start_time, end_time)
+      rights_backend.in(tuples_from_feed)
+        .merge rights_backend.changed_between(start_time, end_time)
+    end
+
+    private
+
+    attr_reader :rights_backend, :feed_backend
+
+  end
+end

--- a/lib/datasets/repository/rights_volume_repo.rb
+++ b/lib/datasets/repository/rights_volume_repo.rb
@@ -1,0 +1,75 @@
+require "volume_repo"
+require "volume"
+require "set"
+require "sequel"
+
+module Repository
+  class RightsVolumeRepo < VolumeRepo
+
+    def initialize(connection)
+      @connection = connection
+      @table_name = :rights_current
+    end
+
+    # Retrieve all unique volumes that match the namespace-id pairs.
+    # The list is unordered.
+    # @param [Array<Hash>] pairs Each element should be a hash containing
+    #   the key *:namespace* and the key *:id*.
+    # @return Set<Volume>
+    def in(pairs)
+      project(
+        joined_tables
+          .where([Sequel[table_name][:namespace], Sequel[table_name][:id]] => format_pairs(pairs))
+      )
+    end
+
+    # Retrieve all unique volumes that have had a change in
+    # their rights within the given time period.
+    # The list is unordered.
+    # @param [Time] start_time
+    # @param [Time] end_time
+    # @return Set<Volume>
+    def changed_between(start_time, end_time)
+      project(
+        joined_tables.where(time: start_time..end_time)
+      )
+    end
+
+
+
+    private
+
+    attr_reader :connection, :table_name
+
+    def project(dataset)
+      dataset
+        .select(Sequel[table_name][:id])
+        .select_append(Sequel[table_name][:namespace])
+        .select_append(Sequel.as(Sequel[:access_profiles][:name], :access_profile))
+        .select_append(Sequel.as(Sequel[:attributes][:name], :attribute))
+        .map{|row| row_to_volume(row) }
+        .to_set
+    end
+
+    def format_pairs(pairs)
+      pairs.map{|h| [h.fetch(:namespace, ""), h.fetch(:id, "")] }
+    end
+
+    def joined_tables
+      connection[table_name]
+        .join(:access_profiles, id: :access_profile)
+        .join(:attributes, id: Sequel[table_name][:attr])
+        .join(:reasons, id: Sequel[table_name][:reason])
+        .join(:sources, id: Sequel[table_name][:source])
+    end
+
+    def row_to_volume(row)
+      Volume.new(
+        namespace: row[:namespace],
+        id: row[:id],
+        access_profile: row[:access_profile].to_sym,
+        right: row[:attribute].to_sym
+      )
+    end
+  end
+end

--- a/lib/datasets/volume.rb
+++ b/lib/datasets/volume.rb
@@ -10,4 +10,13 @@ class Volume
     @right = right.to_sym
   end
 
+  def ==(other)
+    namespace == other.namespace &&
+      id == other.id &&
+      access_profile == other.access_profile &&
+      right == other.right
+  end
+
+  alias_method :eql?, :==
+
 end

--- a/lib/datasets/volume_repo.rb
+++ b/lib/datasets/volume_repo.rb
@@ -1,18 +1,9 @@
 # Interface for retrieving volumes from the rights database.
 class VolumeRepo
-  # Retrieve all unique volumes that have had a change in
-  # their rights within the given time period.
-  # The list is unordered.
+  # Retrieve all unique volumes that have changed
+  # within the given time period. The list is unordered.
   # @param [Time] start_time
   # @param [Time] end_time
   # @return Set<Volume>
-  def rights_changed_between(start_time, end_time); end
-
-  # Retrieve all unique volumes that have had a content
-  # change within the given time period.
-  # The list is unordered.
-  # @param [Time] start_time
-  # @param [Time] end_time
-  # @return Set<Volume>
-  def zip_changed_between(start_time, end_time); end
+  def changed_between(start_time, end_time); end
 end

--- a/spec/repository/feed_backend_spec.rb
+++ b/spec/repository/feed_backend_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+require "repository/feed_backend"
+require "volume"
+
+require "set"
+require "sequel"
+require "sqlite3"
+require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/hash/slice"
+
+
+RSpec.describe Repository::FeedBackend do
+  before(:all) do
+    @connection = Sequel.sqlite
+    FeedSchemaBuilder.new(@connection).create!
+  end
+
+  around(:example) do |example|
+    @connection.transaction(rollback: :always, auto_savepoint: true) {example.run}
+  end
+
+  let(:table) { @connection.from(:feed_audit) }
+  let(:repo) { described_class.new(@connection) }
+
+  let(:t1) do
+    {
+      namespace: "mdp", id: "123098120312",
+      zip_size: 3013480, zip_date: Time.new(2001, 3, 27),
+      mets_size: 3232, mets_date: Time.new(2000, 9, 29),
+      lastchecked: Time.new(2017, 1, 1), zipcheck_ok: true
+    }
+  end
+  let(:t2) do
+    {
+      namespace: "inu", id: "300000312",
+      zip_size: 10398103, zip_date: Time.new(2011, 2, 22),
+      mets_size: 1111, mets_date: Time.new(2001, 1, 15),
+      lastchecked: Time.new(2016, 5, 15), zipcheck_ok: nil
+    }
+  end
+  let(:t3) do
+    {
+      namespace: "mdp", id: "asldfasdfasdf",
+      zip_size: 99999, zip_date: Time.new(2005, 1, 14),
+      mets_size: 3232, mets_date: Time.new(2000, 2, 29),
+      lastchecked: Time.new(2016, 2, 23), zipcheck_ok: true
+    }
+  end
+
+  describe "#zip_changed_between" do
+    it "returns :namespace :id pairs as hashes" do
+      table.insert t1
+      tuples = repo.changed_between(t1[:zip_date] - 1.day, t1[:zip_date] + 1.day)
+      expect(tuples).to contain_exactly(t1.slice(:namespace, :id))
+    end
+
+    it "returns an empty set when nothing to find" do
+      table.insert t1
+      expect(repo.changed_between(t1[:zip_date] + 1.day, t1[:zip_date] + 2.minutes))
+        .to eql Set.new
+    end
+
+    it "returns tuples with a zip_date in the range" do
+      table.insert(t1.merge(zip_date: Time.new(1997, 12, 25)))
+      table.insert(t2.merge(zip_date: Time.new(2002, 10, 31)))
+      table.insert(t3.merge(zip_date: Time.new(2017, 1, 1)))
+      tuples = repo.changed_between(Time.new(2001, 1, 1), Time.new(2016, 1, 1))
+      expect(tuples).to contain_exactly(t2.slice(:namespace, :id))
+    end
+
+    it "does not return volumes with zipcheck_ok: false" do
+      table.insert t1.merge(zipcheck_ok: false, zip_date: Time.now)
+      expect(repo.changed_between(1.day.ago, 1.day.from_now)).to eql Set.new
+    end
+
+    it "does return volumes with zipcheck_ok: true or null" do
+      table.insert t1.merge(zipcheck_ok: true, zip_date: Time.now)
+      table.insert t2.merge(zipcheck_ok: nil, zip_date: Time.now)
+      expect(repo.changed_between( 1.day.ago, 1.day.from_now))
+        .to contain_exactly(t1.slice(:namespace, :id), t2.slice(:namespace, :id))
+    end
+
+  end
+
+end

--- a/spec/repository/rights_feed_volume_repo_spec.rb
+++ b/spec/repository/rights_feed_volume_repo_spec.rb
@@ -1,0 +1,29 @@
+require "datasets/repository/rights_feed_volume_repo"
+
+RSpec.describe Repository::RightsFeedVolumeRepo do
+  let(:rights_volumes) { Set.new([double(:v1), double(:v2), double(:v3) ]) }
+  let(:feed_tuples) { Set.new([double(:t1), double(:t2), double(:t3)]) }
+  let(:feed_volumes) { Set.new([double(:v3), double(:v4), double(:v5)]) }
+  let(:rights_backend) { double(:rights) }
+  let(:feed_backend) { double(:feed) }
+  let(:start_time) { Time.at(0) }
+  let(:end_time) { Time.now }
+  let(:repo) do
+    described_class.new(
+      rights_backend: rights_backend,
+      feed_backend: feed_backend
+    )
+  end
+
+
+
+  it "returns the changed rights and feed volumes" do
+    allow(feed_backend).to receive(:changed_between).with(start_time, end_time)
+      .and_return(feed_tuples)
+    allow(rights_backend).to receive(:in).with(feed_tuples).and_return(feed_volumes)
+    allow(rights_backend).to receive(:changed_between).with(start_time, end_time)
+      .and_return(rights_volumes)
+    expect(repo.changed_between(start_time, end_time)).to eql(feed_volumes + rights_volumes)
+  end
+
+end

--- a/spec/repository/rights_volume_repo_spec.rb
+++ b/spec/repository/rights_volume_repo_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+require "repository/rights_volume_repo"
+require "volume"
+
+require "set"
+require "sequel"
+require "sqlite3"
+require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/hash/slice"
+
+
+RSpec.describe Repository::RightsVolumeRepo do
+  before(:all) do
+    @connection = Sequel.sqlite
+    @schema_builder = RightsSchemaBuilder.new(@connection)
+    @schema_builder.create!
+  end
+
+  around(:example) do |example|
+    @connection.transaction(rollback: :always, auto_savepoint: true) {example.run}
+  end
+
+  let(:table) { @connection.from(:rights_current) }
+  let(:repo) { described_class.new(@connection) }
+  let(:tuple_1) do
+    {
+      namespace: "mdp", id: "120398120938",
+      attr: 1, reason: 1, source: 1, access_profile: 1,
+      user: "someuser", time: Time.new(1997, 12, 25)
+    }
+  end
+  let(:tuple_2) do
+    {
+      namespace: "mdp", id: "22222222",
+      attr: 1, reason: 1, source: 1, access_profile: 1,
+      user: "someuser", time: Time.new(2002, 10, 31)
+    }
+  end
+  let(:tuple_3) do
+    {
+      namespace: "mdp", id: "3333333333",
+      attr: 1, reason: 1, source: 1, access_profile: 1,
+      user: "someuser", time: Time.new(2017, 1, 1)
+    }
+  end
+
+  def volume_from(hash)
+    Volume.new(
+      namespace: hash[:namespace],
+      id: hash[:id],
+      access_profile: @schema_builder.access_profile(hash[:access_profile])[:name].to_sym,
+      right: @schema_builder.attribute(hash[:attr])[:name].to_sym
+    )
+  end
+
+  describe "#in" do
+    it "returns Volume objects" do
+      table.insert(tuple_1)
+      volumes = repo.in([tuple_1.slice(:namespace, :id)])
+      expect(volumes.first).to be_an_instance_of Volume
+    end
+
+    it "finds the selected volumes" do
+      table.insert tuple_1
+      table.insert tuple_2
+      table.insert tuple_3
+      volumes = repo.in([
+        tuple_1.slice(:namespace, :id),
+        tuple_2.slice(:namespace, :id)
+      ])
+      expect(volumes).to contain_exactly(volume_from(tuple_1), volume_from(tuple_2))
+    end
+
+    it "returns empty set when there are no volumes to find" do
+      table.insert tuple_1
+      expect(repo.in [{namespace: "nope", id: "notgonnahappen"}]).to eql Set.new
+    end
+
+  end
+
+  describe "#rights_changed_between" do
+    it "returns Volume objects" do
+      table.insert(tuple_1)
+      volumes = repo.changed_between(Time.at(0), tuple_1[:time] + 1.day)
+      expect(volumes.first).to be_an_instance_of Volume
+    end
+
+    it "returns only those volumes in the range" do
+      table.insert(tuple_1.merge(time: Time.new(1997, 12, 25)))
+      table.insert(tuple_2.merge(time: Time.new(2002, 10, 31)))
+      table.insert(tuple_3.merge(time: Time.new(2017, 1, 1)))
+      volumes = repo.changed_between(Time.new(2001, 1, 1), Time.new(2016, 1, 1))
+      expect(volumes).to contain_exactly(volume_from(tuple_2))
+    end
+
+    it "returns empty set when there are no volumes to find" do
+      table.insert(tuple_1.merge(time: Time.new(2017)))
+      expect(repo.changed_between(Time.new(2015), Time.new(2016))).to eql Set.new
+    end
+  end
+
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.disable_monkey_patching!
-  config.warnings = true
+  config.warnings = false
 
   if config.files_to_run.one?
     config.default_formatter = 'doc'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $: << File.expand_path(File.join(File.dirname(__FILE__), "../lib/datasets"))
 
+Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/config/ht_rights/access_profiles.csv
+++ b/spec/support/config/ht_rights/access_profiles.csv
@@ -1,0 +1,5 @@
+id,name,dscr
+1,open,open description
+2,google,googl description
+3,page, page desc
+4,page+lowres,page+lowres description

--- a/spec/support/config/ht_rights/attributes.csv
+++ b/spec/support/config/ht_rights/attributes.csv
@@ -1,0 +1,28 @@
+id,type,name,dscr
+1,copyright,pd,public domain
+2,copyright,ic,in copyright
+3,copyright,op,out-of-print (implies in-copyright)
+4,copyright,orph,copyright-orphaned (implies in-copyright)
+6,access,umall,available to UM affiliates and walk-in patrons (all campuses)
+7,access,ic-world,in-copyright and permitted as world viewable by the copyright holder
+5,copyright,und,undetermined copyright status
+8,access,nobody,available to nobody; blocked for all users
+9,copyright,pdus,public domain only when viewed in the US
+10,copyright,cc-by-3.0,"Creative Commons Attribution license, 3.0 Unported"
+11,copyright,cc-by-nd-3.0,"Creative Commons Attribution-NoDerivatives license, 3.0 Unported"
+12,copyright,cc-by-nc-nd-3.0,"Creative Commons Attribution-NonCommercial-NoDerivatives license, 3.0 Unported"
+13,copyright,cc-by-nc-3.0,"Creative Commons Attribution-NonCommercial license, 3.0 Unported"
+14,copyright,cc-by-nc-sa-3.0,"Creative Commons Attribution-NonCommercial-ShareAlike license, 3.0 Unported"
+15,copyright,cc-by-sa-3.0,"Creative Commons Attribution-ShareAlike license, 3.0 Unported"
+16,copyright,orphcand,orphan candidate - in 90-day holding period (implies in-copyright)
+17,copyright,cc-zero,Creative Commons Zero license (implies pd)
+18,access,und-world,undetermined copyright status and permitted as world viewable by the depositor
+19,copyright,icus,in copyright in the US
+20,copyright,cc-by-4.0,Creative Commons Attribution 4.0 International license
+21,copyright,cc-by-nd-4.0,Creative Commons Attribution-NoDerivatives 4.0 International license
+22,copyright,cc-by-nc-nd-4.0,Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
+23,copyright,cc-by-nc-4.0,Creative Commons Attribution-NonCommercial 4.0 International license
+24,copyright,cc-by-nc-sa-4.0,Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International license
+25,copyright,cc-by-sa-4.0,Creative Commons Attribution-ShareAlike 4.0 International license
+26,access,pd-pvt,public domain but access limited due to privacy concerns
+27,access,supp,suppressed from view; see note for details

--- a/spec/support/config/ht_rights/reasons.csv
+++ b/spec/support/config/ht_rights/reasons.csv
@@ -1,0 +1,19 @@
+id,name,dscr
+1,bib,bibliographically-derived by automatic processes
+2,ncn,no printed copyright notice
+3,con,contractual agreement with copyright holder on file
+4,ddd,due diligence documentation on file
+5,man,manual access control override; see note for details
+6,pvt,private personal information visible
+7,ren,copyright renewal research was conducted
+8,nfi,"needs further investigation (copyright research partially complete, and an ambiguous, unclear, or other time-consuming situation was encountered)"
+9,cdpp,title page or verso contain copyright date and/or place of publication information not in bib record
+10,ipma,in-print and market availability research was conducted
+11,unp,unpublished work
+12,gfv,Google viewability set at VIEW_FULL
+13,crms,derived from multiple reviews in the Copyright Review Management System (CRMS) via an internal resolution policy; consult CRMS records for details
+14,add,author death date research was conducted or notification was received from authoritative source
+15,exp,expiration of copyright term for non-US work with corporate author
+16,del,deleted from the repository; see note for details
+17,gatt,non-US public domain work restored to in-copyright in the US by GATT
+18,supp,suppressed from view; see note for details

--- a/spec/support/config/ht_rights/sources.csv
+++ b/spec/support/config/ht_rights/sources.csv
@@ -1,0 +1,46 @@
+id,name,dscr,access_profile,digitization_source
+1,google,Google,2,google
+2,lit-dlps-dc,"University of Michigan Library IT, Digital Library Production Service, Digital Conversion",1,umich*;umdl-umich
+3,ump,University of Michigan Press,3,umich;press-umich*
+4,ia,Internet Archive,1,archive
+5,yale,Yale University (with support from Microsoft),1,yale;ht_support-microsoft*
+6,mdl,Minnesota Digital Library,4,mndigital
+7,mhs,Minnesota Historical Society,4,mnhs
+8,usup,Utah State University Press,3,usupress
+9,ucm,Universidad Complutense de Madrid,1,ucm
+10,purd,Purdue University,1,purdue
+11,getty,Getty Research Institute,1,getty
+12,um-dc-mp,"University of Michigan, Duderstadt Center, Millennium Project",1,umich;milproj-dc-umich*
+13,uiuc,University of Illinois at Urbana-Champaign,1,illinois
+14,brooklynmuseum,Brooklyn Museum,1,brooklynmuseum
+15,uf,State University System of Florida,1,flbog
+16,tamu,Texas A&M,1,tamu
+17,udel,University of Delaware,1,udel
+18,private,Private Donor,1,ht_private
+19,umich,University of Michigan (Other),1,umich
+20,clark,Clark Art Institute,1,clarkart
+21,ku,Knowledge Unlatched,1,knowledgeunlatched
+22,mcgill,McGill University,1,mcgill
+23,bc,Boston College,1,bc
+24,nnc,Columbia University,1,columbia
+25,geu,Emory University,1,emory
+26,borndigital,Born Digital (placeholder),1,NULL
+27,yale2,Yale University,1,yale
+28,mou,University of Missouri,1,missouri
+29,chtanc,National Central Library of Taiwan,1,washington;ncl
+30,bentley-umich,"Bentley Historical Library, University of Michigan",1,umich*;bentley-umich
+31,clements-umich,"William L. Clements Library, University of Michigan",1,umich*;clements-umich
+32,wau,University of Washington,1,washington
+33,cornell,Cornell University,1,cornell
+34,cornell-ms,Cornell University (with support from Microsoft),1,cornell*;ht_support-microsoft
+35,umd,University of Maryland,1,umd
+36,frick,The Frick Collection,1,frick
+37,northwestern,Northwestern University,1,northwestern
+38,umn,University of Minnesota,1,umn
+39,berkeley,"University of California, Berkeley",1,berkeley
+40,ucmerced,"University of California, Merced",1,ucmerced
+41,nd,University of Notre Dame,1,nd
+42,princeton,Princeton University,1,princeton
+43,uq,The University of Queensland,1,uq
+44,ucla,"University of California, Los Angeles",1,ucla
+45,osu,The Ohio State University,1,osu

--- a/spec/support/feed_schema_builder.rb
+++ b/spec/support/feed_schema_builder.rb
@@ -1,0 +1,25 @@
+class FeedSchemaBuilder
+
+  def initialize(connection)
+    @connection = connection
+  end
+
+  def create!
+    connection.create_table(:feed_audit) do
+      String :namespace, size: 8, null: false
+      String :id, size: 32, null: false
+      Bignum :zip_size, size: 20, null: true
+      Time :zip_date, null: true
+      Bignum :mets_size, size: 20, null: true
+      Time :mets_date, null: true
+      Time :lastchecked, null: false
+      TrueClass :zipcheck_ok, null: true
+      primary_key [:namespace, :id]
+    end
+  end
+
+  private
+
+  attr_reader :connection
+
+end

--- a/spec/support/rights_schema_builder.rb
+++ b/spec/support/rights_schema_builder.rb
@@ -1,0 +1,110 @@
+require "csv"
+
+class RightsSchemaBuilder
+
+  def initialize(connection)
+    @connection = connection
+  end
+
+  def create!
+    create_access_profiles
+    create_attributes
+    create_reasons
+    create_sources
+    create_rights_current
+    populate!
+  end
+
+  def access_profile(id)
+    @connection.from(:access_profiles).where(id: id).first
+  end
+
+  def attribute(id)
+    @connection.from(:attributes).where(id: id).first
+  end
+
+  def reason(id)
+    @connection.from(:reasons).where(id: id).first
+  end
+
+  def source(id)
+    @connection.from(:sources).where(id: id).first
+  end
+
+  private
+
+  attr_reader :connection
+
+  def config_file(filename)
+    @dir ||= File.dirname(File.expand_path(__FILE__))
+    File.join @dir, "config", "ht_rights", filename
+  end
+
+  def csv(path)
+    CSV.read(path, headers: true, header_converters: :symbol, converters: :all)
+  end
+
+  def insert_from_csv(name)
+    csv(config_file("#{name}.csv")).each do |row|
+      connection[name.to_sym].insert(row.to_h)
+    end
+  end
+
+  def populate!
+    [:access_profiles, :attributes, :reasons, :sources].each do |name|
+      insert_from_csv(name)
+    end
+  end
+
+  def create_access_profiles
+    connection.create_table(:access_profiles) do
+      primary_key :id
+      String :name, size: 16, null: false
+      String :dscr, text: true, null: false
+    end
+  end
+
+
+  def create_attributes
+    connection.create_table(:attributes) do
+      primary_key :id
+      String :type, null: false, default: "access"
+      String :name, size: 16, null: false, default: ""
+      String :dscr, text: true, null: false
+    end
+  end
+
+  def create_reasons
+    connection.create_table(:reasons) do
+      primary_key :id
+      String :name, size: 16, null: false, default: ""
+      String :dscr, text: true, null: false
+    end
+  end
+
+  def create_rights_current
+    connection.create_table(:rights_current) do
+      String :namespace, size: 8, null: false
+      String :id, size: 32, null: false, default: ""
+      Integer :attr, null: false
+      Integer :reason, null: false
+      Integer :source, null: false
+      Integer :access_profile, null: false
+      String :user, size: 32, null: false, default: ""
+      Time :time, null: false
+      primary_key [:namespace, :id]
+    end
+  end
+
+  def create_sources
+    connection.create_table(:sources) do
+      primary_key :id
+      String :name, size: 16, null: false, default: ""
+      String :dscr, text: true, null: false
+      Integer :access_profile
+      String :digitization_source, size: 64
+    end
+  end
+
+
+end


### PR DESCRIPTION
Resolves #17 
Resolves #18 

This changes the VolumeRepo interface to only have one method, `#changed_between`.  Instead of needing to determine the appropriate method(s) to use, we can now inject the proper implementation into the scheduler: RightsVolumeRepo for subsets, and RightsFeedVolumeRepo for ht_text.