### PR TITLE
Small change to make Volume coerce its fields

### DIFF
--- a/lib/datasets/volume.rb
+++ b/lib/datasets/volume.rb
@@ -4,10 +4,10 @@ class Volume
     :access_profile, :right
 
   def initialize(namespace:, id:, access_profile:, right:)
-    @namespace = namespace
-    @id = id
-    @access_profile = access_profile
-    @right = right
+    @namespace = namespace.to_s
+    @id = id.to_s
+    @access_profile = access_profile.to_sym
+    @right = right.to_sym
   end
 
 end

--- a/spec/volume_spec.rb
+++ b/spec/volume_spec.rb
@@ -1,0 +1,35 @@
+require_relative "./spec_helper.rb"
+require "datasets/volume"
+
+RSpec.describe Volume do
+  shared_examples "coerces parameters" do
+    let(:volume) { described_class.new(volume_params) }
+    [:namespace, :id].each do |field|
+      it "##{field} is a string" do
+        expect(volume.public_send(field)).to eql(volume_params[field].to_s)
+      end
+    end
+    [:access_profile, :right].each do |field|
+      it "##{field} is a symbol" do
+        expect(volume.public_send(field)).to eql(volume_params[field].to_sym)
+      end
+    end
+  end
+
+  context "given string parameters" do
+    let(:volume_params) do
+      { namespace: "mdp", id: "12356",
+        access_profile: "open", right: "pd"}
+    end
+    include_examples "coerces parameters"
+  end
+
+  context "given symbol parameters" do
+    let(:volume_params) do
+      { namespace: :mdp, id: :"8675309",
+        access_profile: :closed, right: :nobody}
+    end
+    include_examples "coerces parameters"
+  end
+
+end


### PR DESCRIPTION
Coerces `namespace` and `id` to string, as this vocabulary is uncontrolled.  Coerces `access_profile` and `right` to symbol, as we control those.  Includes tests.