### PR TITLE
Logging & specs for scheduler

### DIFF
--- a/lib/datasets/scheduler.rb
+++ b/lib/datasets/scheduler.rb
@@ -1,42 +1,47 @@
+# frozen_string_literal: true
 require "datasets/jobs/save_job"
 require "datasets/jobs/delete_job"
 
 # Adds volumes to a dataset
 module Datasets
   class Scheduler
-
     # @param [VolumeRepo] volume_repo
     # @param [PathResolver] src_path_resolver
     # @param [VolumeWriter] volume_writer
     # @param [Filter] filter
     # @param [Time] last_run_time
-    def initialize(volume_repo:, src_path_resolver:, volume_writer:, filter:, last_run_time:)
+    # @param [VolumeActionLogger] logger
+    def initialize(volume_repo:, src_path_resolver:, volume_writer:, filter:, last_run_time:, logger:)
       @volume_repo = volume_repo
       @src_path_resolver = src_path_resolver
       @volume_writer = volume_writer
       @filter = filter
       @last_run_time = last_run_time
+      @logger = logger
     end
 
     def add
-      volumes = volume_repo.changed_between(last_run_time, Time.now)
-      volumes.select { |v| filter.matches?(v) }
-        .map{|volume| [volume, src_path_resolver.path(volume)] }
-        .map{|volume, src_path| CreateJob.new(volume, src_path, volume_writer) }
-        .each{|job| job.enqueue }
+      volume_repo.changed_between(last_run_time, Time.now)
+        .select {|v| filter.matches?(v) }
+        .map {|volume| [volume, src_path_resolver.path(volume)] }
+        .each do |volume, src_path|
+        SaveJob.new(volume, src_path, volume_writer).enqueue
+        logger.log("save", volume, src_path)
+      end
     end
 
     def delete
-      volumes = volume_repo.changed_between(last_run_time, Time.now)
-      volumes.select { |v| !filter.matches?(v) }
-        .map{|volume| DeleteJob.new(volume, volume_writer) }
-        .each{|job| job.enqueue }
+      volume_repo.changed_between(last_run_time, Time.now)
+        .select {|v| !filter.matches?(v) }
+        .each do |volume|
+        DeleteJob.new(volume, volume_writer).enqueue
+        logger.log("delete", volume, src_path_resolver.path(volume))
+      end
     end
 
     private
 
     attr_reader :volume_repo, :src_path_resolver,
-      :volume_writer, :filter, :last_run_time
-
+      :volume_writer, :filter, :last_run_time, :logger
   end
 end

--- a/lib/datasets/volume.rb
+++ b/lib/datasets/volume.rb
@@ -1,4 +1,5 @@
 
+# frozen_string_literal: true
 module Datasets
   class Volume
     attr_reader :namespace, :id,
@@ -25,6 +26,10 @@ module Datasets
         namespace: namespace, id: id,
         access_profile: access_profile, right: right
       }
+    end
+
+    def to_s
+      "#{namespace}.#{id} #{right} #{access_profile}"
     end
 
   end

--- a/lib/datasets/volume_action_logger.rb
+++ b/lib/datasets/volume_action_logger.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Datasets
+  class VolumeActionLogger
+    def initialize(io)
+      @io = io
+    end
+
+    def log(action, volume, path)
+      io.puts([Time.now.iso8601, action, volume, path]
+        .join(" "))
+    end
+
+    private
+
+    attr_reader :io
+  end
+end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "datasets/volume_action_logger"
+
+module Datasets
+  ISO8601_REGEX = '\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}'
+  TEST_VOLUME_PATH = "/path/to/test.1234"
+  RSpec.describe VolumeActionLogger do
+    let(:output) { StringIO.new }
+    let(:logger) { VolumeActionLogger.new(output) }
+    let(:volume) { Volume.new(namespace: "test", id: "1234", access_profile: :open, right: :pd) }
+
+    describe "#new" do
+      it "accepts an IO object" do
+        expect(logger).not_to be_nil
+      end
+    end
+
+    describe "#log" do
+      it "outputs a timestamp, the action, the volume ID, and its corresponding path" do
+        logger.log(:save, volume, TEST_VOLUME_PATH)
+        expect(output.string).to match(/^#{ISO8601_REGEX} save test.1234 pd open #{TEST_VOLUME_PATH}$/)
+      end
+    end
+  end
+end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+require_relative "./spec_helper"
+require "scheduler"
+
+module Datasets
+  RSpec.describe Scheduler do
+    let(:repo) { double(:repo) }
+    let(:src) { double(:src_path_resovler) }
+    let(:writer) { double(:writer) }
+    let(:filter) { double(:filter) }
+    let(:start_time) { Time.local(2017, 1, 12) }
+    let(:end_time) { Time.now }
+    let(:log) { StringIO.new }
+    let(:logger) { double(:logger) }
+    let(:scheduler) do
+      described_class.new(
+        volume_repo: repo, src_path_resolver: src,
+        volume_writer: writer, filter: filter,
+        last_run_time: start_time,
+        logger: logger
+      )
+    end
+    let(:in_volumes) { [double(:v1), double(:v2), double(:v3)] }
+    let(:src_paths) { [:path1, :path2, :path3] }
+    let(:out_volumes) { [double(:v4), double(:v5)] }
+    let(:create_job) { double(:create_job) }
+    let(:delete_job) { double(:delete_job) }
+
+    before(:each) do
+      allow(repo).to receive(:changed_between).with(start_time, anything)
+        .and_return(in_volumes + out_volumes)
+
+      allow(src).to receive(:path).and_return(*src_paths)
+      allow(Datasets::SaveJob).to receive(:new).and_return(create_job)
+      allow(create_job).to receive(:enqueue)
+
+      allow(delete_job).to receive(:enqueue)
+      allow(Datasets::DeleteJob).to receive(:new).and_return(delete_job)
+
+      allow(logger).to receive(:log)
+
+      in_volumes.each {|v| allow(filter).to receive(:matches?).with(v).and_return(true) }
+      out_volumes.each {|v| allow(filter).to receive(:matches?).with(v).and_return(false) }
+    end
+
+    describe "#add" do
+      it "enqueues a Datasets::SaveJob for each volume that satisfies the filter" do
+        expect(create_job).to receive(:enqueue).exactly(in_volumes.count).times
+
+        scheduler.add
+      end
+
+      it "passes each volume and its path to the job" do
+        in_volumes.zip(src_paths).each do |volume, path|
+          expect(Datasets::SaveJob).to receive(:new)
+            .with(volume, path, anything)
+        end
+
+        scheduler.add
+      end
+
+      it "passes the volume_writer to each Datasets::SaveJob" do
+        expect(Datasets::SaveJob).to receive(:new).with(anything, anything, writer)
+          .exactly(in_volumes.count).times
+
+        scheduler.add
+      end
+
+      it "logs each volume that satisfies the filter" do
+        in_volumes.zip(src_paths).each do |volume, path|
+          expect(logger).to receive(:log).with("save", volume, path)
+        end
+
+        scheduler.add
+      end
+    end
+
+    describe "#delete" do
+      it "enqueues a Datasets::DeleteJob for each volume that does not satisfy the filter" do
+        expect(delete_job).to receive(:enqueue).exactly(out_volumes.count).times
+
+        scheduler.delete
+      end
+
+      it "passes the volume to the job" do
+        out_volumes.each do |volume|
+          expect(Datasets::DeleteJob).to receive(:new)
+            .with(volume, anything)
+        end
+
+        scheduler.delete
+      end
+
+      it "passes the volume_writer to each Datasets::DeleteJob" do
+        expect(Datasets::DeleteJob).to receive(:new).with(anything, writer)
+          .exactly(out_volumes.count).times
+
+        scheduler.delete
+      end
+
+      it "logs each volume that satisfies the filter" do
+        out_volumes.each do |volume|
+          expect(logger).to receive(:log).with("delete", volume, anything)
+        end
+
+        scheduler.delete
+      end
+    end
+  end
+end

--- a/spec/volume_spec.rb
+++ b/spec/volume_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "./spec_helper.rb"
 require "datasets/volume"
 
@@ -20,7 +21,7 @@ module Datasets
     context "given string parameters" do
       let(:volume_params) do
         { namespace: "mdp", id: "12356",
-          access_profile: "open", right: "pd"}
+          access_profile: "open", right: "pd" }
       end
       include_examples "coerces parameters"
     end
@@ -28,21 +29,29 @@ module Datasets
     context "given symbol parameters" do
       let(:volume_params) do
         { namespace: :mdp, id: :"8675309",
-          access_profile: :closed, right: :nobody}
+          access_profile: :closed, right: :nobody }
       end
       include_examples "coerces parameters"
     end
 
-    describe "#to_h" do
+    context "given common volume" do
       let(:volume_params) do
-        { namespace: "mdp", id: "8675309",
-          access_profile: :closed, right: :nobody}
+        { namespace: "mdp", id: "12356",
+          access_profile: :open, right: :pd }
       end
       let(:volume) { described_class.new(volume_params) }
-      it "returns a hash representing the volume" do
-        expect(volume.to_h).to eql(volume_params)
+
+      describe "#to_h" do
+        it "returns a hash representing the volume" do
+          expect(volume.to_h).to eql(volume_params)
+        end
+      end
+
+      describe "#to_s" do
+        it "returns a string with the volume ID and the rights" do
+          expect(volume.to_s).to eql("mdp.12356 pd open")
+        end
       end
     end
-
   end
 end


### PR DESCRIPTION
Addresses #10, #12, although an orchestration object still would need to coordinate setting up the logger and ensuring output gets directed appropriately.

Not sure if we need to address this immediately, but worth thinking about: the scheduler object has a lot of dependencies and in turn that requires a lot of mocks in the test. We could consider wrapping up all those things in an actual "Dataset" object. Let's see where the configuration stuff ends up, that might inform our approach.