### PR TITLE
resolve current errors from resque

### DIFF
--- a/lib/datasets/filesystem.rb
+++ b/lib/datasets/filesystem.rb
@@ -23,13 +23,19 @@ module Datasets
       path.exist?
     end
 
+    # @param [Pathname] path
+    # @return [Boolean]
+    def symlink?(path)
+      path.symlink?
+    end
+
     # Create a symlink at #dest_path to #src_path.
     # If the file already exists, whether it is a
     # link or a normal file, we return success.
     # @param [Pathname] src_path
     # @param [Pathname] dest_path
     def ln_s(src_path, dest_path)
-      unless exists?(dest_path)
+      unless exists?(dest_path) or symlink?(dest_path)
         dest_path.make_symlink src_path
       end
     end

--- a/lib/datasets/zip_writer.rb
+++ b/lib/datasets/zip_writer.rb
@@ -14,8 +14,8 @@ module Datasets
     # and copies them to output zip.
     def write(src_path, dest_path, &block)
       tmp_path = dest_path.dirname.join(Dir::Tmpname.make_tmpname('dataset', '.zip'))
-      Zip::File.open(src_path) do |input_zip|
-        Zip::File.open(tmp_path, Zip::File::CREATE) do |output_zip|
+      Zip::File.open(src_path.to_s) do |input_zip|
+        Zip::File.open(tmp_path.to_s, Zip::File::CREATE) do |output_zip|
           (block || copy_text).call input_zip, output_zip
         end
       end

--- a/spec/filesystem_spec.rb
+++ b/spec/filesystem_spec.rb
@@ -90,6 +90,12 @@ module Datasets
             fs.ln_s(src_file_path, dest_path)
           }.to_not raise_error
         end
+        it "is idempotent if src does not exist" do
+          expect {
+            fs.ln_s(src_file_path, dest_path)
+            fs.ln_s(src_file_path, dest_path)
+          }.to_not raise_error
+        end
         it "is successful if dest is already a file" do
           File.write(src_file_path, "contents")
           File.write(dest_path, "other contents")


### PR DESCRIPTION
rubyzip has some internals that uses is_a?, so we need to
make sure we pass an actual string to ensure we don't get
unexpected behavior. See for example https://github.com/rubyzip/rubyzip/blob/master/lib/zip/streamable_stream.rb#L5 - if zipfile is not a string, tempfiles get created in unexpected places.