### PR TITLE
ensure zips & mets are named using pt-encoded filenames

### DIFF
--- a/lib/datasets/volume_creator.rb
+++ b/lib/datasets/volume_creator.rb
@@ -1,4 +1,5 @@
 require "datasets/volume_writer"
+require "pairtree"
 
 # Writes and deletes volumes within the superset.
 module Datasets
@@ -34,7 +35,7 @@ module Datasets
     # @param [Pathname] path
     # @return [Pathname]
     def zip_path(volume, path)
-      path + "#{volume.id}.zip"
+      path + "#{pt_id(volume)}.zip"
     end
 
     # Path of the mets for the volume at path
@@ -42,7 +43,7 @@ module Datasets
     # @param [Pathname] path
     # @return [Pathname]
     def mets_path(volume, path)
-      path + "#{volume.id}.mets.xml"
+      path + "#{pt_id(volume)}.mets.xml"
     end
 
     private
@@ -59,6 +60,10 @@ module Datasets
 
     def should_write_zip?(src_path, dest_path)
       !fs.exists?(dest_path) || fs.modify_time(src_path) > fs.modify_time(dest_path)
+    end
+
+    def pt_id(volume)
+      Pairtree::Identifier.encode(volume.id)
     end
 
   end

--- a/spec/pairtree_path_resolver_spec.rb
+++ b/spec/pairtree_path_resolver_spec.rb
@@ -4,16 +4,33 @@ require "pairtree_path_resolver"
 module Datasets
   RSpec.describe PairtreePathResolver do
     let(:parent_dir) { "/parent/dir" }
-    let(:namespace) { "mdp" }
-    let(:id) { "11223344556677" }
+    let(:resolver) { described_class.new(parent_dir) }
     let(:volume) { double(:volume, namespace: namespace, id: id)}
 
     describe "#path" do
-      it "constructs the path from the volume" do
-        resolver = described_class.new(parent_dir)
-        expect(resolver.path(volume))
-          .to eql Pathname.new(File.join(parent_dir, "obj", namespace, "pairtree_root", "11/22/33/44/55/66/77", id))
+      context "with a barcode id" do 
+        let(:namespace) { "mdp" }
+        let(:id) { "39015012345678" }
+
+        it "constructs the path from the volume" do
+          expect(resolver.path(volume))
+            .to eql Pathname.new(File.join(parent_dir, "obj", namespace, 
+          "pairtree_root", "39/01/50/12/34/56/78", id))
+        end
+      end
+
+      context "with an arkid" do
+        let(:namespace) { "loc" }
+        let(:id) { "ark:/13960/t7jq2979w" }
+
+        it "constructs the path from the volume" do
+          expect(resolver.path(volume))
+            .to eql Pathname.new(File.join(parent_dir, "obj", namespace, 
+          "pairtree_root", "ar/k+/=1/39/60/=t/7j/q2/97/9w", "ark+=13960=t7jq2979w"))
+        end
+
       end
     end
+
   end
 end

--- a/spec/volume_creator_spec.rb
+++ b/spec/volume_creator_spec.rb
@@ -1,110 +1,121 @@
+# frozen_string_literal: true
 require_relative "./spec_helper"
 require "volume_creator"
 require "pathname"
 
 module Datasets
   RSpec.describe VolumeCreator do
-    let(:volume) do
-      double(:volume,
-        namespace: "mdp",
-        id: "112233445566"
-      )
-    end
-    let(:dest_path) { Pathname.new("/dest/path/to/11/22/33/44/55/66") }
-
-    let(:fs) do
-      double(:fs,
-        mkdir_p: nil,
-        ln_s: nil,
-        remove: nil,
-        rm_empty_tree: nil
-      )
-    end
-    let(:id) { :some_id }
-    let(:dest_path_resolver) { double(:dpr, path: dest_path) }
-    let(:writer) { double(:writer, write: nil) }
-    let(:volume_creator) do
-      described_class.new(
-        id: id,
-        dest_path_resolver: dest_path_resolver,
-        writer: writer, fs: fs)
-    end
-
-    describe "#id" do
-      it "has an id" do
-        expect(volume_creator.id).to_not be_nil
+    shared_examples_for "a volume creator" do |namespace, volume_id, pt_volume_id, pt_path|
+      let(:fs) do
+        double(:fs,
+          mkdir_p: nil,
+          ln_s: nil,
+          remove: nil,
+          rm_empty_tree: nil)
       end
-    end
 
-    describe "#save" do
-      let(:src_path) { Pathname.new("/src/path/to/volume") }
-      let(:src_zip) { src_path + "#{volume.id}.zip" }
-      let(:dest_zip) { dest_path + "#{volume.id}.zip" }
-      let(:src_mets) { src_path + "#{volume.id}.mets.xml" }
-      let(:dest_mets) { dest_path + "#{volume.id}.mets.xml" }
-
-
-      context "destination zip not present" do
-        before(:each) do
-          allow(fs).to receive(:exists?).with(dest_zip).and_return(false)
-          volume_creator.save(volume, src_path)
-        end
-        it "creates the directory tree including final dir" do
-          expect(fs).to have_received(:mkdir_p).with(dest_path)
-        end
-        it "links the mets" do
-          expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
-        end
-        it "creates the zip" do
-          expect(writer).to have_received(:write).with(src_zip, dest_zip)
-        end
+      let(:volume) do
+        double(:volume,
+          namespace: namespace,
+          id: volume_id)
       end
-      context "destination zip present and newer than src" do
-        before(:each) do
-          allow(fs).to receive(:exists?).with(dest_zip).and_return(true)
-          allow(fs).to receive(:modify_time).with(src_zip).and_return(Time.at(0))
-          allow(fs).to receive(:modify_time).with(dest_zip).and_return(Time.at(9999))
-          volume_creator.save(volume, src_path)
-        end
-        it "creates the directory tree including final dir" do
-          expect(fs).to have_received(:mkdir_p).with(dest_path)
-        end
-        it "links the mets" do
-          expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
-        end
-        it "does not create the zip" do
-          expect(writer).to_not have_received(:write)
-        end
+
+      let(:dest_path) { Pathname.new("/dest/#{pt_path}/#{volume_id}") }
+      let(:src_path) { Pathname.new("/src/#{pt_path}/#{volume_id}") }
+      let(:src_zip) { src_path + "#{pt_volume_id}.zip" }
+      let(:dest_zip) { dest_path + "#{pt_volume_id}.zip" }
+      let(:src_mets) { src_path + "#{pt_volume_id}.mets.xml" }
+      let(:dest_mets) { dest_path + "#{pt_volume_id}.mets.xml" }
+
+      let(:dest_path_resolver) { double(:dpr, path: dest_path) }
+
+      let(:writer) { double(:writer, write: nil) }
+      let(:vol_creator_id) { :some_id }
+      let(:volume_creator) do
+        described_class.new(
+          id: vol_creator_id,
+          dest_path_resolver: dest_path_resolver,
+          writer: writer, fs: fs
+        )
       end
-      context "destination zip present and older than src" do
-        before(:each) do
-          allow(fs).to receive(:exists?).with(dest_zip).and_return(true)
-          allow(fs).to receive(:modify_time).with(src_zip).and_return(Time.at(9999))
-          allow(fs).to receive(:modify_time).with(dest_zip).and_return(Time.at(0))
-          volume_creator.save(volume, src_path)
-        end
-        it "creates the directory tree including final dir" do
-          expect(fs).to have_received(:mkdir_p).with(dest_path)
-        end
-        it "links the mets" do
-          expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
-        end
-        it "creates the zip" do
-          expect(writer).to have_received(:write).with(src_zip, dest_zip)
+
+      describe "#id" do
+        it "has an id" do
+          expect(volume_creator.id).to_not be_nil
         end
       end
 
+      describe "#save" do
+        context "destination zip not present" do
+          before(:each) do
+            allow(fs).to receive(:exists?).with(dest_zip).and_return(false)
+            volume_creator.save(volume, src_path)
+          end
+          it "creates the directory tree including final dir" do
+            expect(fs).to have_received(:mkdir_p).with(dest_path)
+          end
+          it "links the mets" do
+            expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
+          end
+          it "creates the zip" do
+            expect(writer).to have_received(:write).with(src_zip, dest_zip)
+          end
+        end
+        context "destination zip present and newer than src" do
+          before(:each) do
+            allow(fs).to receive(:exists?).with(dest_zip).and_return(true)
+            allow(fs).to receive(:modify_time).with(src_zip).and_return(Time.at(0))
+            allow(fs).to receive(:modify_time).with(dest_zip).and_return(Time.at(9999))
+            volume_creator.save(volume, src_path)
+          end
+          it "creates the directory tree including final dir" do
+            expect(fs).to have_received(:mkdir_p).with(dest_path)
+          end
+          it "links the mets" do
+            expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
+          end
+          it "does not create the zip" do
+            expect(writer).to_not have_received(:write)
+          end
+        end
+        context "destination zip present and older than src" do
+          before(:each) do
+            allow(fs).to receive(:exists?).with(dest_zip).and_return(true)
+            allow(fs).to receive(:modify_time).with(src_zip).and_return(Time.at(9999))
+            allow(fs).to receive(:modify_time).with(dest_zip).and_return(Time.at(0))
+            volume_creator.save(volume, src_path)
+          end
+          it "creates the directory tree including final dir" do
+            expect(fs).to have_received(:mkdir_p).with(dest_path)
+          end
+          it "links the mets" do
+            expect(fs).to have_received(:ln_s).with(src_mets, dest_mets)
+          end
+          it "creates the zip" do
+            expect(writer).to have_received(:write).with(src_zip, dest_zip)
+          end
+        end
+      end
+
+      describe "#delete" do
+        before(:each) { volume_creator.delete(volume) }
+        it "deletes the directory (and contents)" do
+          expect(fs).to have_received(:remove).with(dest_path)
+        end
+        it "deletes empty directory tree branches" do
+          expect(fs).to have_received(:rm_empty_tree).with(dest_path.parent)
+        end
+      end
     end
 
-    describe "#delete" do
-      before(:each) { volume_creator.delete(volume) }
-      it "deletes the directory (and contents)" do
-        expect(fs).to have_received(:remove).with(dest_path)
-      end
-      it "deletes empty directory tree branches" do
-        expect(fs).to have_received(:rm_empty_tree).with(dest_path.parent)
-      end
+    context "with a barcode id" do
+      it_behaves_like "a volume creator", "mdp", "39015012345678",
+        "39015012345678", "mdp/39/01/50/12/34/56/78"
     end
 
+    context "with an arkid" do
+      it_behaves_like "a volume creator", "loc", "ark:/13960/t7jq2979w",
+        "ark+=13960=t7jq2979w", "loc/pairtree_root/ar/k+/=1/39/60/=t/7j/q2/97/9w"
+    end
   end
 end


### PR DESCRIPTION
This adds pairtree as a dependency of VolumeCreator. Not sure what we think of that - it might be better to keep it isolated to the path resolvers and have them know about how to construct the zip/mets path as well. However, then we would need to pass the source path resolver as a parameter to the jobs and not just the source path. Ultimately that might be preferable, but it does require quite a bit of refactoring that I don't want to get into right now. I'll create an issue but go ahead and merge this for now.