### PR TITLE
resque-pool: don't fork for every job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,13 +25,16 @@ namespace :resque do
 
   namespace :pool do
     task :setup => "resque:setup" do
-      Resque::Pool.after_prefork do |_|
+      Resque::Pool.after_prefork do |worker|
+        # ensure workers don't share parent redis connection
         Resque.redis.client.reconnect
+        # don't fork a new process for every job - in particular this prevents
+        # using a new connection to redis for every job
+        worker.fork_per_job = false
       end
     end
   end
 
   task :scheduler => :setup
-
 
 end


### PR DESCRIPTION
This prevents reconnecting to redis for every child and causing the OS connection table to fill up with lots of connections in the TIME_WAIT state.

I think the main risk here is potential memory leaks that are out of our control, but so far I'm not seeing a huge amount of growth - seems relatively stable around 200MB resident per child after running for a while, but there might be some slow growth and it's definitely worth observing. If we do see issues we could consider a couple things:

- Try to find out where the memory leaks are (good luck)
- Sidestep with periodic resque-pool restarts (reasonable easy mitigation for now)
- Turn fork per child on; enable the redis `inherit_socket: true` option; somehow prevent Resque workers from reconnecting after forking for a job - probably would need to subclass `Resque::Worker` and then have `resque-pool` set up those instead of `Resque::Worker`s.. This will slow things down some but probably not that much, and would be a good thing to consider if we find ourselves needing to do frequent restarts. We should be getting some speedup from avoiding the fork, but I don't know how much that is compared to avoiding the Redis reconnect.

There are also some attempts out there to address this issue by adding support for multiple jobs per child, e.g. https://github.com/stulentsev/resque-multi-job-forks - not clear to me how fresh any of these things are. This one in particular just monkey patches `Resque::Worker` anyway...