### PR TITLE
Log outcome of jobs

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -4,6 +4,7 @@
 # Datasets::Hathitrust::Configuration.
 
 src_parent_dir: '/sdr1'
+worker_log_path: 'DATASETS_HOME/log'
 
 report_dir:
   :full: 'DATASETS_HOME/ht_text/history'

--- a/lib/datasets/filesystem.rb
+++ b/lib/datasets/filesystem.rb
@@ -34,9 +34,13 @@ module Datasets
     # link or a normal file, we return success.
     # @param [Pathname] src_path
     # @param [Pathname] dest_path
+    # @return [Boolean] true if link was created; false otherwise.
     def ln_s(src_path, dest_path)
       unless exists?(dest_path) or symlink?(dest_path)
         dest_path.make_symlink src_path
+        true
+      else
+        false
       end
     end
 
@@ -55,10 +59,15 @@ module Datasets
     end
 
     # rm -rf #path. Idempotent.
+    #
+    # @return [Boolean] true if something changed; false otherwise.
     # @param [Pathname] path
     def remove(path)
       if exists?(path)
         FileUtils.remove_entry_secure path
+        true
+      else
+        false
       end
     end
 

--- a/lib/datasets/volume.rb
+++ b/lib/datasets/volume.rb
@@ -29,7 +29,7 @@ module Datasets
     end
 
     def to_s
-      "#{namespace}.#{id} #{right} #{access_profile}"
+      "#{namespace}.#{id} (#{right} #{access_profile})"
     end
 
     def hash

--- a/lib/datasets/volume_creator.rb
+++ b/lib/datasets/volume_creator.rb
@@ -26,7 +26,8 @@ module Datasets
 
     def delete(volume)
       dest_path = dest_path_resolver.path(volume)
-      fs.remove(dest_path)
+      removed = fs.remove(dest_path)
+      log(volume,removed ? 'removed' : 'not present')
       fs.rm_empty_tree(dest_path.parent)
     end
 
@@ -55,6 +56,9 @@ module Datasets
       dest_zip = zip_path(volume, dest_path)
       if should_write_zip?(src_zip, dest_zip)
         writer.write(src_zip, dest_zip)
+        log(volume,'updated')
+      else
+        log(volume,'up to date')
       end
     end
 

--- a/lib/datasets/volume_linker.rb
+++ b/lib/datasets/volume_linker.rb
@@ -1,7 +1,7 @@
 # Writes and deletes symlinks within the subsets
 # to the superset.
 module Datasets
-  class VolumeLinker
+  class VolumeLinker < VolumeWriter
 
     # @param [PathResolver] dest_path_resolver
     # @param [Filesystem] fs
@@ -21,7 +21,8 @@ module Datasets
     def save(volume, src_path)
       dest_path = dest_path_resolver.path(volume)
       fs.mkdir_p dest_path.parent
-      fs.ln_s src_path.relative_path_from(dest_path.parent), dest_path
+      linked = fs.ln_s src_path.relative_path_from(dest_path.parent), dest_path
+      log(volume, linked ? 'added' : 'already present')
     end
 
     # Delete a link for the volume within the
@@ -32,7 +33,8 @@ module Datasets
     # @param [Volume] volume
     def delete(volume)
       dest_path = dest_path_resolver.path(volume)
-      fs.remove(dest_path)
+      removed = fs.remove(dest_path)
+      log(volume, removed ? 'removed' : 'not present')
       fs.rm_empty_tree(dest_path.parent)
     end
 

--- a/lib/datasets/volume_writer.rb
+++ b/lib/datasets/volume_writer.rb
@@ -16,5 +16,9 @@ module Datasets
     # @param [Volume] volume
     def delete(volume); end
 
+    def log(volume,action)
+      Resque.logger.info("profile: #{id}, volume: #{volume}: #{action}")
+    end
+
   end
 end

--- a/spec/filesystem_spec.rb
+++ b/spec/filesystem_spec.rb
@@ -109,6 +109,13 @@ module Datasets
           File.write(src_file_path, "contents")
           expect(File.read(dest_path)).to eql("contents")
         end
+        it "returns true when it creates a symlink" do
+          expect(fs.ln_s(src_file_path, dest_path)).to be true
+        end
+        it "returns false when destination already exists" do
+          fs.ln_s(src_file_path, dest_path)
+          expect(fs.ln_s(src_file_path, dest_path)).to be false
+        end
       end
 
       describe "#mkdir_p" do
@@ -151,6 +158,13 @@ module Datasets
           expect{
             fs.remove(file_path)
           }.to_not raise_error
+        end
+        it "returns true when something was removed" do
+          File.write(file_path, "contents")
+          expect(fs.remove(file_path)).to be true
+        end
+        it "returns false when nothing was removed" do
+          expect(fs.remove(file_path)).to be false
         end
       end
       describe "#rm_empty_tree" do

--- a/spec/job_helper.rb
+++ b/spec/job_helper.rb
@@ -1,15 +1,14 @@
 require "resque"
+require "datasets"
 
 Resque.inline = true
 
 shared_context "with mocked job parameters" do
   let(:volume) do
-    {
-      namespace: "test",
+    { namespace: "test",
       id: "test_id",
       access_profile: :test_profile,
-      right: :test_right
-    }
+      right: :test_right }
   end
   let(:src_path) { Pathname.new("some/path")}
   let(:volume_writer) { double(:volume_writer, id: :something, delete: nil) }

--- a/spec/jobs/scheduler_job_spec.rb
+++ b/spec/jobs/scheduler_job_spec.rb
@@ -6,6 +6,7 @@ require "pathname"
 module Datasets
 
   RSpec.describe SchedulerJob do
+    include_context "with mocked resque logger"
     let(:profile) { :pd }
 
     it_behaves_like "a job" do

--- a/spec/support/contexts/with_mocked_resque_logger.rb
+++ b/spec/support/contexts/with_mocked_resque_logger.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context "with mocked resque logger" do
+  before(:each) do
+    Resque.logger = double(:logger,
+                           info: nil,
+                           debug: nil)
+  end
+end

--- a/spec/volume_linker_spec.rb
+++ b/spec/volume_linker_spec.rb
@@ -1,14 +1,17 @@
 require_relative "./spec_helper"
 require "volume_linker"
 require "pathname"
+require "pry"
 
 module Datasets
   RSpec.describe VolumeLinker do
+    include_context "with mocked resque logger"
+
+    LOG_PREFIX = "profile: some_id, volume: mocked_volume"
+
     let(:fs) do
       double(:fs,
         mkdir_p: nil,
-        ln_s: nil,
-        remove: nil,
         rm_empty_tree: nil
       )
     end
@@ -16,6 +19,7 @@ module Datasets
     let(:dest_path) { Pathname.new("/dest/path/to/volume") }
     let(:dest_path_resolver) { double(:dpr, path: dest_path) }
     let(:volume_linker) { described_class.new(id: id, dest_path_resolver: dest_path_resolver, fs: fs) }
+    let(:volume) { double(:volume, to_s: "mocked_volume") }
 
     describe "#id" do
       it "has an id" do
@@ -24,26 +28,65 @@ module Datasets
     end
 
     describe "#save" do
-      let(:volume) { double(:volume) }
       let(:src_path) { Pathname.new("/src/path/to/volume") }
       let(:path_from_dest_to_src) { Pathname.new "../../../src/path/to/volume" }
-      before(:each) { volume_linker.save(volume, src_path) }
-      it "creates the directory tree of the parent dir" do
-        expect(fs).to have_received(:mkdir_p).with(dest_path.parent)
+
+      context "when the link is not already present" do
+        before(:each) do
+          allow(fs).to receive(:ln_s).and_return(true)
+          volume_linker.save(volume, src_path)
+        end
+
+        it "creates the directory tree of the parent dir" do
+          expect(fs).to have_received(:mkdir_p).with(dest_path.parent)
+        end
+        it "creates a link from src to dest" do
+          expect(fs).to have_received(:ln_s).with(path_from_dest_to_src, dest_path)
+        end
+        it "logs the link creation" do
+          expect(Resque.logger).to have_received(:info).with("#{LOG_PREFIX}: added")
+        end
       end
-      it "creates a link from src to dest" do
-        expect(fs).to have_received(:ln_s).with(path_from_dest_to_src, dest_path)
+
+      context "when the link is already present" do
+        before(:each) do
+          allow(fs).to receive(:ln_s).and_return(false)
+          volume_linker.save(volume, src_path)
+        end
+
+        it "logs the no-op" do
+          expect(Resque.logger).to have_received(:info).with("#{LOG_PREFIX}: already present")
+        end
       end
     end
 
     describe "#delete" do
-      let(:volume) { double(:volume) }
-      before(:each) { volume_linker.delete(volume) }
-      it "deletes the link" do
-        expect(fs).to have_received(:remove).with(dest_path)
+      context "when the link is present at removal time" do
+        before(:each) do 
+          allow(fs).to receive(:remove).and_return(true) 
+          volume_linker.delete(volume)
+        end
+
+        it "deletes the link" do
+          expect(fs).to have_received(:remove).with(dest_path)
+        end
+        it "deletes empty directory tree branches" do
+          expect(fs).to have_received(:rm_empty_tree).with(dest_path.parent)
+        end
+        it "logs the deletion" do
+          expect(Resque.logger).to have_received(:info).with("#{LOG_PREFIX}: removed")
+        end
       end
-      it "deletes empty directory tree branches" do
-        expect(fs).to have_received(:rm_empty_tree).with(dest_path.parent)
+
+      context "when the link is not present at removal time" do
+        before(:each) do
+          allow(fs).to receive(:remove).and_return(false)
+          volume_linker.delete(volume)
+        end
+
+        it "logs the no-op" do
+          expect(Resque.logger).to have_received(:info).with("#{LOG_PREFIX}: not present")
+        end
       end
     end
 

--- a/spec/volume_spec.rb
+++ b/spec/volume_spec.rb
@@ -57,7 +57,7 @@ module Datasets
 
       describe "#to_s" do
         it "returns a string with the volume ID and the rights" do
-          expect(volume.to_s).to eql("mdp.12356 pd open")
+          expect(volume.to_s).to eql("mdp.12356 (pd open)")
         end
       end
 


### PR DESCRIPTION
- `Datasets::Filesystem#delete` and `#ln_s` now return true or false based on whether they actually made a change. (Note: the only idempotency guarantee is in terms of the state of the filesystem and that it won't raise errors. This is not a change - there was no guarantee of strict idempotency in terms of function return values before, since `delete` and `ln_s` just returned whatever the underlying filesystem call returned.)
- Volumes are formatted slightly differently to make logs more readable
- Each worker logs in its own file named with the host, PID and date
- Future work: log to a common place or in a more structured fashion

